### PR TITLE
add .npmignore (closes #6)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+*
+!Avatar.vue
+!readme.md
+!package.json


### PR DESCRIPTION
This adds an `.npmignore` that ignores all files except:

```
Avatar.vue
package.json
readme.md
```
Below is the dry-run of an npm publish so you can see the files that would be published & the size:

```
npm notice === Tarball Contents === 
npm notice 597B  package.json
npm notice 2.4kB Avatar.vue  
npm notice 5.0kB readme.md   
npm notice === Tarball Details === 
npm notice name:          vue-avatar-component                    
npm notice version:       1.2.5                                   
npm notice package size:  3.1 kB                                  
npm notice unpacked size: 8.0 kB               
```

The package size has been reduced by 85%